### PR TITLE
chore: remove core team from dependabot reviews

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,5 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "masa-finance/core-team"
+      - "masa-finance/smart-contracts"
+      - "masa-finance/protocol"


### PR DESCRIPTION
Put instead most common contributors which are smart contracts team and masa protocol team