### PR TITLE
Added Masa package installation is Vali setup steps

### DIFF
--- a/docs/masa-subnet/shared/setup-environment.md
+++ b/docs/masa-subnet/shared/setup-environment.md
@@ -55,4 +55,5 @@ source bittensor/bin/activate
 
 ```bash
 pip install -r requirements.txt
+pip install -e .
 ```


### PR DESCRIPTION
Had to execute this command in order to install the Masa package.

Without it, `masa dependencies was not found` errors were thrown.