### PR TITLE
feat (docs): Add Miner Scoring System documentation

### DIFF
--- a/docs/resources/miner-scoring.md
+++ b/docs/resources/miner-scoring.md
@@ -1,0 +1,63 @@
+---
+id: miner-scoring
+title: Miner Scoring System
+---
+
+# Understanding the Masa Network's Miner Scoring System
+
+Masa's SN42 uses a sophisticated scoring system to evaluate and reward miners based on their tweet volume. This system incentivizes consistent and valuable contributions while discouraging extreme fluctuations or gaming attempts.
+
+## The Kurtosis-Based Scoring Function
+
+At the core of our scoring system is the `kurtosis_based_score` function. Here's how it works:
+
+1. **Measuring Relative Performance**: Compare each miner's tweet volume to the average volume of all miners.
+2. **Standardization**: Use z-score to standardize comparisons.
+3. **Probability Transformation**: Convert z-score to probability using a normal distribution curve.
+
+:::info
+The probability transformation "squishes" extreme values towards the middle, reducing the impact of outliers.
+:::
+
+## Advantages of This Approach
+
+- **Fairness**: Accounts for network-wide trends.
+- **Consistency Rewarded**: Consistent above-average performers score well.
+- **Outlier Management**: Extremely high volumes don't result in proportionally high scores.
+- **Adaptability**: Automatically adjusts to changing network conditions.
+
+## In Practice
+
+Consider three miners:
+
+1. **Average Alice**: Volume at network average.
+2. **Consistent Carl**: Always about 20% above average.
+3. **Sporadic Sam**: Fluctuates wildly, sometimes 5x average, sometimes near zero.
+
+:::tip
+Our scoring system would likely rank them: Carl > Alice > Sam. Carl's consistency is rewarded, while Sam's extreme fluctuations are dampened.
+:::
+
+## Security Considerations
+
+- The system is designed to be manipulation-resistant.
+- The scoring mechanism naturally discourages extreme fluctuations in tweet volume.
+- The scoring system is designed to be transparent and verifiable, with all scores and calculations being made public.
+- Validators spot check miners tweets using tweet IDs against the Twitter API to ensure the tweets are real and not duplicate tweets.
+
+:::warning
+Attempts to game the system through sporadic bursts of activity are unlikely to result in high scores. Additionaly validators spot check miners tweets using tweet IDs against the Twitter API to ensure the tweets are real and not duplicate tweets.
+:::
+
+## Conclusion
+
+This scoring mechanism balances rewarding high performance with maintaining a fair system. It encourages miners to strive for consistent, above-average contributions rather than sporadic bursts of activity.
+
+:::note
+By using this approach, the Masa Network aims to create a stable, reliable ecosystem where genuine value creation is recognized and rewarded.
+:::
+
+For more information on miner operations, refer to:
+- [Miner Setup Guide](./miner-setup.md)
+- [Network Performance Metrics](./network-metrics.md)
+- [Reward Distribution](./reward-distribution.md)

--- a/docs/resources/miner-scoring.md
+++ b/docs/resources/miner-scoring.md
@@ -44,6 +44,7 @@ Our scoring system would likely rank them: Carl > Alice > Sam. Carl's consistenc
 - The scoring mechanism naturally discourages extreme fluctuations in tweet volume.
 - The scoring system is designed to be transparent and verifiable, with all scores and calculations being made public.
 - Validators spot check miners tweets using tweet IDs against the Twitter API to ensure the tweets are real and not duplicate tweets.
+- Organic tweets are currently not scored. 
 
 :::warning
 Attempts to game the system through sporadic bursts of activity are unlikely to result in high scores. Additionaly validators spot check miners tweets using tweet IDs against the Twitter API to ensure the tweets are real and not duplicate tweets.

--- a/sidebars.js
+++ b/sidebars.js
@@ -132,6 +132,17 @@ const sidebars = {
         },
       ],
     },
+    {
+      type: "category",
+      label: "Resources",
+      link: {
+        type: "generated-index",
+        title: "Resources",
+      },
+      items: [
+        "resources/miner-scoring",
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
## Description
This PR introduces a new "Resources" section to our documentation, featuring a detailed explanation of the Miner Scoring System used in the Masa Network's SN42.

## Changes
- Added a new markdown file `docs/resources/miner-scoring.md` explaining the Miner Scoring System
- Updated `sidebars.js` to include a new "Resources" category with a link to the miner scoring document

## Details
The new miner scoring documentation covers:
- Overview of the kurtosis-based scoring function
- Advantages of the scoring approach
- Practical examples
- Security considerations
- Conclusion and implications for the Masa Network

## Additional Notes
This documentation will help miners understand how their performance is evaluated and incentivize consistent, valuable contributions to the network.